### PR TITLE
Force 12-hour time, even if user's computer prefers 24-hour time

### DIFF
--- a/Sources/Sonar/APIs/OpenRadarRouter.swift
+++ b/Sources/Sonar/APIs/OpenRadarRouter.swift
@@ -15,6 +15,7 @@ enum OpenRadarRouter {
             case .create(let radar):
                 let formatter = DateFormatter()
                 formatter.dateFormat = "dd-MMM-yyyy hh:mm a"
+                formatter.locale = Locale(identifier: "en_US_POSIX")
 
                 return (path: "/api/radars/add", method: .post, parameters: [
                     "classification": radar.classification.name,


### PR DESCRIPTION
If the user's computer uses 24 hour time the current date formatter will return something like "31-Aug-2017 21:20" instead of ""31-Aug-2017 09:20 PM". Specifying the locale fixes this.