### PR TITLE
Clarify that the error is related to your Apple account

### DIFF
--- a/Sources/Sonar/APIs/SonarError.swift
+++ b/Sources/Sonar/APIs/SonarError.swift
@@ -14,7 +14,7 @@ public struct SonarError: Error {
 
     /// Use when a 412 is received. This happens when you haven't accepted a new agreement
     static let preconditionError = SonarError(
-        message: "Precondition failed, try logging in on the web to validate your account")
+        message: "Precondition failed, try logging in on the web to validate your Apple developer account")
 
     init(message: String) {
         self.message = message


### PR DESCRIPTION
Got 

```
Precondition failed, try logging in on the web to validate your account
```

today when I tried to post a radar. I double checked everything related to my OpenRadar API key when I tried to post a radar today. It didn't occur to me that the error was related to the Apple account and it was driving me nuts 😄 

Hope this slight variation of the error message helps.