### PR TITLE
Retrieve products and areas directly from Radar

### DIFF
--- a/Sources/Sonar/APIs/AppleRadar.swift
+++ b/Sources/Sonar/APIs/AppleRadar.swift
@@ -97,6 +97,28 @@ final class AppleRadar: BugTracker {
                 }
     }
 
+    func fetchProductAreaList(closure: @escaping (Result<[Product], SonarError>) -> Void) {
+        guard let token = self.token else {
+            closure(.failure(SonarError(message: "User is not logged in")))
+            return
+        }
+
+        self.manager
+            .request(AppleRadarRouter.getProductAreaList(token: token))
+            .validate()
+            .responseData { response in
+                guard let data = response.data else {
+                    closure(.failure(SonarError.preconditionError))
+                    return
+                }
+
+                let decoder = JSONDecoder()
+                let products = try? decoder.decode([Product].self, from: data)
+
+                closure(.success(products ?? []))
+            }
+    }
+
     // MARK: - Private Functions
 
     private func handleTwoFactorChallenge(code: String, headers: [AnyHashable: Any],

--- a/Sources/Sonar/APIs/AppleRadarRouter.swift
+++ b/Sources/Sonar/APIs/AppleRadarRouter.swift
@@ -17,6 +17,7 @@ enum AppleRadarRouter {
     case authorizeTwoFactor(code: String, scnt: String, sessionID: String)
     case accessToken
     case create(radar: Radar, token: String)
+    case getProductAreaList(token: String)
     case sessionID
     case viewProblem
     case uploadAttachment(radarID: Int, attachment: Attachment, token: String)
@@ -117,6 +118,14 @@ enum AppleRadarRouter {
                 ]
                 return (path: "/developerUI/problem/createNewDevUIProblem", method: .post, headers: headers,
                         data: body, parameters: [:])
+
+            case .getProductAreaList(let token):
+                let headers = [
+                    "Referer": AppleRadarRouter.viewProblem.url.absoluteString,
+                    "Radar-Authentication": token,
+                    ]
+
+                return (path: "/developerUI/problem/getProductAreaList", method: .get, headers:headers, data: nil, parameters: [:])
 
             case .uploadAttachment(let radarID, let attachment, let token):
                 let escapedName = attachment.filename

--- a/Sources/Sonar/Models/Area.swift
+++ b/Sources/Sonar/Models/Area.swift
@@ -1,16 +1,26 @@
-public struct Area: Equatable {
+public struct Area: Decodable, Equatable {
     /// Internal apple's identifier
     public let appleIdentifier: Int
-
     /// The name of the area; useful to use as display name (e.g. 'App Switcher').
     public let name: String
-
-    public init(appleIdentifier: Int, name: String) {
-        self.appleIdentifier = appleIdentifier
-        self.name = name
-    }
+    /// Indicates if the area is active.
+    public let isActive: Bool
 
     public static func == (lhs: Area, rhs: Area) -> Bool {
         return lhs.appleIdentifier == rhs.appleIdentifier && lhs.name == rhs.name
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.appleIdentifier = try container.decode(Int.self, forKey: .appleIdentifier)
+        self.isActive = try container.decode(Bool.self, forKey: .isActive)
+        self.name = try container.decode(String.self, forKey: .name)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case appleIdentifier = "id"
+        case isActive
+        case name
     }
 }

--- a/Sources/Sonar/Models/ModelsData.swift
+++ b/Sources/Sonar/Models/ModelsData.swift
@@ -31,6 +31,7 @@ extension Area {
     private init(_ appleIdentifier: Int, _ name: String) {
         self.appleIdentifier = appleIdentifier
         self.name = name
+        self.isActive = true
     }
 
     public static func areas(for product: Product) -> [Area] {
@@ -48,7 +49,7 @@ extension Area {
         }
     }
 
-    private static let AlliOSAreas: [Area] = [
+    fileprivate static let AlliOSAreas: [Area] = [
         Area(1, "Accelerate Framework"), Area(2, "Accessibility"), Area(3, "Accounts Framework"),
         Area(4, "App Store"), Area(5, "App Switcher"), Area(6, "ARKit"), Area(7, "Audio"),
         Area(8, "Audio Toolbox"), Area(9, "AVFoundation"), Area(10, "AVKit"), Area(11, "Battery Life"),
@@ -80,7 +81,7 @@ extension Area {
         Area(101, "Wi-Fi"), Area(102, "Xcode"), Area(103, "Something not on this list"),
     ]
 
-    private static let AllmacOSAreas: [Area] = [
+    fileprivate static let AllmacOSAreas: [Area] = [
         Area(1, "Accessibility"), Area(2, "Airplay"), Area(3, "APNS"), Area(4, "App Store"),
         Area(5, "AppKit"), Area(6, "Automation"), Area(7, "Battery"), Area(8, "Bluetooth"),
         Area(9, "Calendar"), Area(10, "Contacts"), Area(11, "Core Graphics"), Area(12, "Developer Web Site"),
@@ -100,7 +101,7 @@ extension Area {
         Area(59, "Something not on this list"),
     ]
 
-    private static let AlltvOSAreas: [Area] = [
+    fileprivate static let AlltvOSAreas: [Area] = [
         Area(1, "Accessibility"), Area(2, "Accounts"), Area(3, "AirPlay"), Area(4, "App Store"),
         Area(5, "App Switcher"), Area(6, "AV Playback"), Area(7, "Bluetooth"),
         Area(8, "Device Management / Profiles"), Area(9, "Display"), Area(10, "Home Screen"),
@@ -111,7 +112,7 @@ extension Area {
         Area(26, "tvOS SDK"),
     ]
 
-    private static let AllwatchOSAreas: [Area] = [
+    fileprivate static let AllwatchOSAreas: [Area] = [
         Area(1, "Accessibility"), Area(2, "Activity"), Area(3, "Battery Life"), Area(4, "Bluetooth"),
         Area(5, "Calendar"), Area(6, "Contacts"), Area(7, "Control Center"), Area(8, "Dock"),
         Area(9, "HealthKit"), Area(10, "HomeKit"), Area(11, "Maps"), Area(12, "Messages"), Area(13, "Music"),
@@ -122,17 +123,19 @@ extension Area {
 }
 
 extension Product {
-    private init(_ appleIdentifier: Int, _ name: String, _ category: String) {
+    private init(_ appleIdentifier: Int, _ name: String, _ category: String, _ areas: [Area] = []) {
         self.appleIdentifier = appleIdentifier
         self.category = category
         self.name = name
+        self.description = ""
+        self.areas = areas
     }
 
-    public static let iOS = Product(579020, "iOS + SDK", "OS and Development")
-    public static let macOS = Product(137701, "macOS + SDK", "OS and Development")
+    public static let iOS = Product(579020, "iOS + SDK", "OS and Development", Area.AlliOSAreas)
+    public static let macOS = Product(137701, "macOS + SDK", "OS and Development", Area.AllmacOSAreas)
     public static let macOSServer = Product(84100, "Server", "OS and Development")
-    public static let tvOS = Product(660932, "tvOS + SDK", "OS and Development")
-    public static let watchOS = Product(645251, "watchOS + SDK", "OS and Development")
+    public static let tvOS = Product(660932, "tvOS + SDK", "OS and Development", Area.AlltvOSAreas)
+    public static let watchOS = Product(645251, "watchOS + SDK", "OS and Development", Area.AllwatchOSAreas)
     public static let DeveloperTools = Product(175326, "Developer Tools", "OS and Development")
     public static let Documentation = Product(183045, "Documentation", "OS and Development")
     public static let iTunesConnect = Product(500515, "iTunes Connect", "OS and Development")

--- a/Sources/Sonar/Models/Product.swift
+++ b/Sources/Sonar/Models/Product.swift
@@ -1,16 +1,51 @@
 import Foundation
 
-public struct Product: Equatable {
+public struct Product: Decodable, Equatable {
     /// Internal apple's identifier
     public let appleIdentifier: Int
     /// The category of the product (e.g. 'Hardware').
     public let category: String
     /// The name of the product; useful to use as display name (e.g. 'iOS').
     public let name: String
+    /// The description of the product; useful to show alonside the name (e.g. 'For issues with iOS utilities and features').
+    public let description: String
+    /// The child areas for this product
+    public let areas: [Area]
 
     public static func == (lhs: Product, rhs: Product) -> Bool {
         return lhs.appleIdentifier == rhs.appleIdentifier
             && lhs.category == rhs.category
             && lhs.name == rhs.name
+    }
+
+    // MARK: - Decodable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let productContainer = try container.nestedContainer(keyedBy: ProductCodingKeys.self, forKey: .product)
+        self.appleIdentifier = try productContainer.decode(Int.self, forKey: .appleIdentifier)
+        self.name = try productContainer.decode(String.self, forKey: .name)
+        self.description = try productContainer.decode(String.self, forKey: .description)
+        self.areas = try productContainer.decode([Area].self, forKey: .areas)
+
+        let sectionContainer = try container.nestedContainer(keyedBy: SectionCodingKeys.self, forKey: .product)
+        self.category = try sectionContainer.decode(String.self, forKey: .section)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case product
+        case section
+    }
+
+    private enum ProductCodingKeys: String, CodingKey {
+        case appleIdentifier = "id"
+        case name
+        case description
+        case areas
+    }
+
+    private enum SectionCodingKeys: String, CodingKey {
+        case section
     }
 }


### PR DESCRIPTION
I'm not sure if this PR is actually useful, but I had a bit of a poke at dynamically retrieving the product/area list from Radar directly so that issues like #40 can be avoided in future. 

I found that (as long as you have a valid token), calling https://bugreport.apple.com/developerUI/problem/getProductAreaList will get you a JSON list of products and their areas, so I added Decodable conformance to the relevant model structs and away we go!